### PR TITLE
Fix decimal validation regex

### DIFF
--- a/UCR/Utilities/Validators/DecimalBindingValidator.cs
+++ b/UCR/Utilities/Validators/DecimalBindingValidator.cs
@@ -11,7 +11,7 @@ namespace HidWizards.UCR.Utilities.Validators
             var text = (string) value;
             if (text == null) return new ValidationResult(false, "No input");
 
-            var regex = new Regex(@"[-+]?[0-9]+\.?[0-9]?");
+            var regex = new Regex(@"^[-+]?[0-9]+\.?[0-9]+?$");
             if (!regex.IsMatch(text)) return new ValidationResult(false, "Invalid input for decimal");
 
             return ValidationResult.ValidResult;


### PR DESCRIPTION
Add anchors to ensure only one match, else 1.2.3.4 could be matched by two matches - `1.2` and `3.4`
Also allow multiple numbers after the decimal point