### PR TITLE
Add ignoring of Visual Studio Code dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Visual Studio 2017 seems to add this folder
 .vs/
 
+# Visual Studio Code create this, and we don't want to track that
+.vscode/
+
 # User-specific files
 *.suo
 *.user


### PR DESCRIPTION
Pretty self-explanatory: add a ignore section for dir created by Visual Studio Code 