### PR TITLE
Implement exception handling for unblocker arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- UCR Unblocker now uses the current directory as default
+
 ## [0.7.0] - 2019-01-03
 
 ### Changed

--- a/UCR.FileHandler/Program.cs
+++ b/UCR.FileHandler/Program.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Runtime.InteropServices;
+using System.IO;
 using HidWizards.UCR.Utilities;
 
 namespace UCR.FileHandler

--- a/UCR.FileHandler/Program.cs
+++ b/UCR.FileHandler/Program.cs
@@ -8,8 +8,25 @@ namespace UCR.FileHandler
     {
         static int Main(string[] args)
         {
-            var success = FileUnblockManager.UnblockAllProgramFiles(args[0]);
+            String directory;
+
+            try
+            {
+                directory = args[0];
+            }
+            catch (IndexOutOfRangeException e)
+            {
+                directory = Directory.GetCurrentDirectory();
+            }
+
+            var success = FileUnblockManager.UnblockAllProgramFiles(directory);
+
             if (!success) return -1;
+
+            Console.WriteLine("Successfully unblocked all files in " + directory);
+            Console.WriteLine("Press any key to close...");
+
+            Console.ReadKey();
 
             return 0;
         }


### PR DESCRIPTION
- Implements basic exception handling for arguments. If an argument is not specified, it assumes the current directory. This fixes an exception that is thrown by referencing args[0] when no argument has been passed.
- Adds a success message if successful.