### PR TITLE
Fix #121

### DIFF
--- a/UCR.Core/Managers/SubscriptionsManager.cs
+++ b/UCR.Core/Managers/SubscriptionsManager.cs
@@ -138,13 +138,13 @@ namespace HidWizards.UCR.Core.Managers
             }
 
             // Output devices
-            var profileOutputDevices = new List<DeviceSubscription>();
             foreach (var device in profile.OutputDevices)
             {
-                profileOutputDevices.Add(state.AddOutputDevice(device, profile));
+                state.AddOutputDevice(device, profile);
             }
 
-            state.AddMappings(profile, profileOutputDevices);
+            // Use all the output devices already added to the state, including implicitly inherited parents' output devices
+            state.AddMappings(profile, state.OutputDeviceSubscriptions);
             
             return success;
         }


### PR DESCRIPTION
PopulateSubscriptionStateForProfile used only the current profile's output DeviceSubscriptions while adding mappings to the subscription state. The added mapping was invalid if the output device was subscribed by its parent.