### PR TITLE
Add tray icon and start minimized CLI argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added option to clear bindings
 - Added Filters for plugins
 - Added System Tray Icon
-- Added Start Hidden CLI Argument
+- Added Minimized mode CLI Argument (-h|hidden)
 - `Button to Filter`: Allows toggling of a filter using a button
 - `Axis to Filter`: Allows toggling of a filter using an axis
 - Added device cache allowing configuration of disconnected devices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added System Tray Icon
+- Added Hidden mode CLI Argument (-h|hidden)
+
 ## [0.9.0] - 2020-01-02
 
 ### Added
@@ -12,8 +17,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added Shadow devices
 - Added option to clear bindings
 - Added Filters for plugins
-- Added System Tray Icon
-- Added Minimized mode CLI Argument (-h|hidden)
 - `Button to Filter`: Allows toggling of a filter using a button
 - `Axis to Filter`: Allows toggling of a filter using an axis
 - Added device cache allowing configuration of disconnected devices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added Shadow devices
 - Added option to clear bindings
 - Added Filters for plugins
+- Added System Tray Icon
+- Added Start Hidden CLI Argument
 - `Button to Filter`: Allows toggling of a filter using a button
 - `Axis to Filter`: Allows toggling of a filter using an axis
 - Added device cache allowing configuration of disconnected devices

--- a/UCR.Core/Context.cs
+++ b/UCR.Core/Context.cs
@@ -36,6 +36,7 @@ namespace HidWizards.UCR.Core
         
         internal bool IsNotSaved { get; private set; }
         internal IOController IOController { get; set; }
+        internal bool StartHidden { get; set; }
         private OptionSet options;
 
         public Context()
@@ -47,6 +48,7 @@ namespace HidWizards.UCR.Core
         private void Init()
         {
             IsNotSaved = false;
+            StartHidden = false;
             Profiles = new List<Profile>();
 
             try
@@ -68,7 +70,8 @@ namespace HidWizards.UCR.Core
         private void SetCommandLineOptions()
         {
             options = new OptionSet {
-                { "p|profile=", "The profile to search for", FindAndLoadProfile }
+                { "p|profile=", "The profile to search for", FindAndLoadProfile },
+                { "h|hidden", "Start with main window hidden", x => StartHidden=true }
             };
         }
 

--- a/UCR.Core/Context.cs
+++ b/UCR.Core/Context.cs
@@ -33,10 +33,10 @@ namespace HidWizards.UCR.Core
 
         public delegate void ActiveProfileChanged(Profile profile);
         public event ActiveProfileChanged ActiveProfileChangedEvent;
+        public event Action MinimizedToTrayEvent;
         
         internal bool IsNotSaved { get; private set; }
         internal IOController IOController { get; set; }
-        internal bool Minimized { get; set; }
         private OptionSet options;
 
         public Context()
@@ -48,7 +48,6 @@ namespace HidWizards.UCR.Core
         private void Init()
         {
             IsNotSaved = false;
-            Minimized = false;
             Profiles = new List<Profile>();
 
             try
@@ -71,7 +70,7 @@ namespace HidWizards.UCR.Core
         {
             options = new OptionSet {
                 { "p|profile=", "The profile to search for", FindAndLoadProfile },
-                { "h|hidden", "Minimize to system tray", x => Minimized=true }
+                { "h|hidden", "Minimize to system tray", x => MinimizedToTrayEvent.Invoke() }
             };
         }
 

--- a/UCR.Core/Context.cs
+++ b/UCR.Core/Context.cs
@@ -36,7 +36,7 @@ namespace HidWizards.UCR.Core
         
         internal bool IsNotSaved { get; private set; }
         internal IOController IOController { get; set; }
-        internal bool StartHidden { get; set; }
+        internal bool Minimized { get; set; }
         private OptionSet options;
 
         public Context()
@@ -48,7 +48,7 @@ namespace HidWizards.UCR.Core
         private void Init()
         {
             IsNotSaved = false;
-            StartHidden = false;
+            Minimized = false;
             Profiles = new List<Profile>();
 
             try
@@ -71,7 +71,7 @@ namespace HidWizards.UCR.Core
         {
             options = new OptionSet {
                 { "p|profile=", "The profile to search for", FindAndLoadProfile },
-                { "h|hidden", "Start with main window hidden", x => StartHidden=true }
+                { "h|hidden", "Minimize to system tray", x => Minimized=true }
             };
         }
 

--- a/UCR.Core/Managers/SubscriptionsManager.cs
+++ b/UCR.Core/Managers/SubscriptionsManager.cs
@@ -28,6 +28,7 @@ namespace HidWizards.UCR.Core.Managers
         }
 
         internal SubscriptionState SubscriptionState { get; set; }
+        private Profile LastProfile;
         private readonly Context _context;
 
         public SubscriptionsManager(Context context)
@@ -40,6 +41,11 @@ namespace HidWizards.UCR.Core.Managers
         public Profile GetActiveProfile()
         {
             return SubscriptionState?.ActiveProfile;
+        }
+
+        public bool ActivateLastProfile()
+        {
+            return ActivateProfile(LastProfile);
         }
 
         public bool ActivateProfile(Profile profile, bool refreshDevices = true)
@@ -83,6 +89,7 @@ namespace HidWizards.UCR.Core.Managers
         {
             // Set new active profile
             SubscriptionState = subscriptionState;
+            LastProfile = profile;
             _context.ActiveProfile = profile;
 
             // Activate plugins

--- a/UCR/App.xaml.cs
+++ b/UCR/App.xaml.cs
@@ -35,8 +35,8 @@ namespace HidWizards.UCR
                 InitializeUcr();
                 CheckForBlockedDll();
 
-                context.ParseCommandLineArguments(e.Args);
                 var mw = new MainWindow(context);
+                context.ParseCommandLineArguments(e.Args);
                 if (!context.StartHidden) mw.Show();
                 else context.StartHidden = false;
             }

--- a/UCR/App.xaml.cs
+++ b/UCR/App.xaml.cs
@@ -19,6 +19,7 @@ namespace HidWizards.UCR
         private Context context;
         private HidGuardianClient _hidGuardianClient;
         private SingleGlobalInstance mutex;
+        private bool StartMinimized;
 
         protected override void OnStartup(StartupEventArgs e)
         {
@@ -36,15 +37,20 @@ namespace HidWizards.UCR
                 CheckForBlockedDll();
 
                 var mw = new MainWindow(context);
+                context.MinimizedToTrayEvent += Context_MinimizedToTrayEvent;
                 context.ParseCommandLineArguments(e.Args);
-                if (!context.Minimized) mw.Show();
-                else context.Minimized = false;
+                if (!StartMinimized) mw.Show();
             }
             else
             {
                 SendArgs(string.Join(";", e.Args));
                 Current.Shutdown();
             }
+        }
+
+        private void Context_MinimizedToTrayEvent()
+        {
+            StartMinimized = true;
         }
 
         private void InitializeUcr()

--- a/UCR/App.xaml.cs
+++ b/UCR/App.xaml.cs
@@ -37,7 +37,8 @@ namespace HidWizards.UCR
 
                 context.ParseCommandLineArguments(e.Args);
                 var mw = new MainWindow(context);
-                mw.Show();
+                if (!context.StartHidden) mw.Show();
+                else context.StartHidden = false;
             }
             else
             {

--- a/UCR/App.xaml.cs
+++ b/UCR/App.xaml.cs
@@ -37,8 +37,8 @@ namespace HidWizards.UCR
 
                 var mw = new MainWindow(context);
                 context.ParseCommandLineArguments(e.Args);
-                if (!context.StartHidden) mw.Show();
-                else context.StartHidden = false;
+                if (!context.Minimized) mw.Show();
+                else context.Minimized = false;
             }
             else
             {

--- a/UCR/UCR.csproj
+++ b/UCR/UCR.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Utilities\NativeMethods.cs" />
     <Compile Include="Utilities\ResourceLoader.cs" />
     <Compile Include="Utilities\SingleGlobalInstance.cs" />
+    <Compile Include="Utilities\UCRTrayIcon.cs" />
     <Compile Include="Utilities\Validators\NumberBindingValidator.cs" />
     <Compile Include="Utilities\Validators\DecimalBindingValidator.cs" />
     <Compile Include="ViewModels\ComboBoxItemViewModel.cs" />

--- a/UCR/Utilities/UCRTrayIcon.cs
+++ b/UCR/Utilities/UCRTrayIcon.cs
@@ -79,12 +79,14 @@ namespace HidWizards.UCR.Utilities
         private void ShowStrip_Click(object sender, EventArgs e)
         {
             _parent.Show();
+            _parent.WindowState = System.Windows.WindowState.Normal;
             _parent.Activate();
         }
 
         private void TrayIcon_OnDoubleClick(object sender, EventArgs e)
         {
             _parent.Show();
+            _parent.WindowState = System.Windows.WindowState.Normal;
             _parent.Activate();
         }
     }

--- a/UCR/Utilities/UCRTrayIcon.cs
+++ b/UCR/Utilities/UCRTrayIcon.cs
@@ -1,11 +1,6 @@
-﻿using HidWizards.UCR.Core;
-using HidWizards.UCR.Core.Models;
+﻿using HidWizards.UCR.Core.Models;
 using HidWizards.UCR.Views;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace HidWizards.UCR.Utilities
@@ -13,43 +8,43 @@ namespace HidWizards.UCR.Utilities
     class UCRTrayIcon
     {
         internal bool Visible { get { return TrayIcon.Visible; } set { TrayIcon.Visible = value; } }
-        private MainWindow _parent;
-        private NotifyIcon TrayIcon = new NotifyIcon();
-        private ToolStripItem ShowStrip = new ToolStripMenuItem();
-        private ToolStripItem StartLastProfileStrip = new ToolStripMenuItem();
-        private ToolStripItem StopProfileStrip = new ToolStripMenuItem();
-        private ToolStripItem ExitStrip = new ToolStripMenuItem();
+        private readonly MainWindow _parent;
+        private readonly NotifyIcon TrayIcon = new NotifyIcon();
+        private readonly ToolStripItem ShowStrip = new ToolStripMenuItem();
+        private readonly ToolStripItem StartLastProfileStrip = new ToolStripMenuItem();
+        private readonly ToolStripItem StopProfileStrip = new ToolStripMenuItem();
+        private readonly ToolStripItem ExitStrip = new ToolStripMenuItem();
 
         public UCRTrayIcon(MainWindow parent)
         {
             ShowStrip.Text = "Show";
-            ShowStrip.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            ShowStrip.DisplayStyle = ToolStripItemDisplayStyle.Text;
             ShowStrip.Click += ShowStrip_Click;
 
             StartLastProfileStrip.Text = "Activate Last Profile";
-            StartLastProfileStrip.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            StartLastProfileStrip.DisplayStyle = ToolStripItemDisplayStyle.Text;
             StartLastProfileStrip.Click += StartLastProfileStrip_Click;
             StartLastProfileStrip.Enabled = false;
 
             StopProfileStrip.Text = "Stop Active Profile";
-            StopProfileStrip.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            StopProfileStrip.DisplayStyle = ToolStripItemDisplayStyle.Text;
             StopProfileStrip.Click += StopProfileStrip_Click; ;
             StopProfileStrip.Enabled = false;
 
             ExitStrip.Text = "Exit";
-            ExitStrip.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            ExitStrip.DisplayStyle = ToolStripItemDisplayStyle.Text;
             ExitStrip.Click += ExitStrip_Click;
 
             _parent = parent;
             _parent.Context.ActiveProfileChangedEvent += Context_ActiveProfileChangedEvent;
 
             TrayIcon.Text = "Universal Control Remapper";
-            TrayIcon.Icon = System.Drawing.Icon.ExtractAssociatedIcon(System.Windows.Forms.Application.ExecutablePath);
+            TrayIcon.Icon = System.Drawing.Icon.ExtractAssociatedIcon(Application.ExecutablePath);
             TrayIcon.DoubleClick += TrayIcon_OnDoubleClick;
-            TrayIcon.ContextMenuStrip = new System.Windows.Forms.ContextMenuStrip();
+            TrayIcon.ContextMenuStrip = new ContextMenuStrip();
             TrayIcon.ContextMenuStrip.ShowCheckMargin = false;
             TrayIcon.ContextMenuStrip.ShowImageMargin = false;
-            TrayIcon.ContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { ShowStrip, new System.Windows.Forms.ToolStripSeparator(), StartLastProfileStrip, StopProfileStrip, new System.Windows.Forms.ToolStripSeparator(), ExitStrip });
+            TrayIcon.ContextMenuStrip.Items.AddRange(new ToolStripItem[] { ShowStrip, new ToolStripSeparator(), StartLastProfileStrip, StopProfileStrip, new ToolStripSeparator(), ExitStrip });
             TrayIcon.Visible = true;
         }
 
@@ -80,7 +75,6 @@ namespace HidWizards.UCR.Utilities
         private void StartLastProfileStrip_Click(object sender, EventArgs e)
         {
             _parent.Context.SubscriptionsManager.ActivateLastProfile();
-            StopProfileStrip.Enabled = true;
         }
         private void ShowStrip_Click(object sender, EventArgs e)
         {
@@ -91,6 +85,7 @@ namespace HidWizards.UCR.Utilities
         private void TrayIcon_OnDoubleClick(object sender, EventArgs e)
         {
             _parent.Show();
+            _parent.Activate();
         }
     }
 }

--- a/UCR/Utilities/UCRTrayIcon.cs
+++ b/UCR/Utilities/UCRTrayIcon.cs
@@ -1,0 +1,96 @@
+﻿using HidWizards.UCR.Core;
+using HidWizards.UCR.Core.Models;
+using HidWizards.UCR.Views;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace HidWizards.UCR.Utilities
+{
+    class UCRTrayIcon
+    {
+        internal bool Visible { get { return TrayIcon.Visible; } set { TrayIcon.Visible = value; } }
+        private MainWindow _parent;
+        private NotifyIcon TrayIcon = new NotifyIcon();
+        private ToolStripItem ShowStrip = new ToolStripMenuItem();
+        private ToolStripItem StartLastProfileStrip = new ToolStripMenuItem();
+        private ToolStripItem StopProfileStrip = new ToolStripMenuItem();
+        private ToolStripItem ExitStrip = new ToolStripMenuItem();
+
+        public UCRTrayIcon(MainWindow parent)
+        {
+            ShowStrip.Text = "Show";
+            ShowStrip.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            ShowStrip.Click += ShowStrip_Click;
+
+            StartLastProfileStrip.Text = "Activate Last Profile";
+            StartLastProfileStrip.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            StartLastProfileStrip.Click += StartLastProfileStrip_Click;
+            StartLastProfileStrip.Enabled = false;
+
+            StopProfileStrip.Text = "Stop Active Profile";
+            StopProfileStrip.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            StopProfileStrip.Click += StopProfileStrip_Click; ;
+            StopProfileStrip.Enabled = false;
+
+            ExitStrip.Text = "Exit";
+            ExitStrip.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            ExitStrip.Click += ExitStrip_Click;
+
+            _parent = parent;
+            _parent.Context.ActiveProfileChangedEvent += Context_ActiveProfileChangedEvent;
+
+            TrayIcon.Text = "Universal Control Remapper";
+            TrayIcon.Icon = System.Drawing.Icon.ExtractAssociatedIcon(System.Windows.Forms.Application.ExecutablePath);
+            TrayIcon.DoubleClick += TrayIcon_OnDoubleClick;
+            TrayIcon.ContextMenuStrip = new System.Windows.Forms.ContextMenuStrip();
+            TrayIcon.ContextMenuStrip.ShowCheckMargin = false;
+            TrayIcon.ContextMenuStrip.ShowImageMargin = false;
+            TrayIcon.ContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { ShowStrip, new System.Windows.Forms.ToolStripSeparator(), StartLastProfileStrip, StopProfileStrip, new System.Windows.Forms.ToolStripSeparator(), ExitStrip });
+            TrayIcon.Visible = true;
+        }
+
+        private void StopProfileStrip_Click(object sender, EventArgs e)
+        {
+            _parent.DeactivateProfile(sender, null);
+        }
+
+        private void Context_ActiveProfileChangedEvent(Profile profile)
+        {
+            if (profile == null)
+            {
+                StopProfileStrip.Enabled = false;
+            }
+            else
+            {
+                StopProfileStrip.Enabled = true;
+                StartLastProfileStrip.Text = $"Activate Last Profile: {profile.Title}";
+                StartLastProfileStrip.Enabled = true;
+            }
+        }
+
+        private void ExitStrip_Click(object sender, EventArgs e)
+        {
+            _parent.Close();
+        }
+
+        private void StartLastProfileStrip_Click(object sender, EventArgs e)
+        {
+            _parent.Context.SubscriptionsManager.ActivateLastProfile();
+            StopProfileStrip.Enabled = true;
+        }
+        private void ShowStrip_Click(object sender, EventArgs e)
+        {
+            _parent.Show();
+            _parent.Activate();
+        }
+
+        private void TrayIcon_OnDoubleClick(object sender, EventArgs e)
+        {
+            _parent.Show();
+        }
+    }
+}

--- a/UCR/Utilities/UCRTrayIcon.cs
+++ b/UCR/Utilities/UCRTrayIcon.cs
@@ -37,10 +37,13 @@ namespace HidWizards.UCR.Utilities
 
             _parent = parent;
             _parent.Context.ActiveProfileChangedEvent += Context_ActiveProfileChangedEvent;
+            _parent.Context.MinimizedToTrayEvent += Context_MinimizedToTrayEvent;
 
             TrayIcon.Text = "Universal Control Remapper";
             TrayIcon.Icon = System.Drawing.Icon.ExtractAssociatedIcon(Application.ExecutablePath);
             TrayIcon.DoubleClick += TrayIcon_OnDoubleClick;
+            TrayIcon.BalloonTipTitle = "UCR Hidden";
+            TrayIcon.BalloonTipText = "UCR has been minimized to the system tray. Double-click the icon to restore, or right click for more options.";
             TrayIcon.ContextMenuStrip = new ContextMenuStrip();
             TrayIcon.ContextMenuStrip.ShowCheckMargin = false;
             TrayIcon.ContextMenuStrip.ShowImageMargin = false;
@@ -65,6 +68,11 @@ namespace HidWizards.UCR.Utilities
                 StartLastProfileStrip.Text = $"Activate Last Profile: {profile.Title}";
                 StartLastProfileStrip.Enabled = true;
             }
+        }
+
+        private void Context_MinimizedToTrayEvent()
+        {
+            TrayIcon.ShowBalloonTip(5000);
         }
 
         private void ExitStrip_Click(object sender, EventArgs e)

--- a/UCR/Views/MainWindow.xaml.cs
+++ b/UCR/Views/MainWindow.xaml.cs
@@ -148,7 +148,7 @@ namespace HidWizards.UCR.Views
 
             if (ProfileWindows.TryGetValue(profileItem.Profile.Guid, out var profileWindow))
             {
-                void FocusAction() => profileWindow.Focus();
+                void FocusAction() { profileWindow.WindowState = WindowState.Normal; profileWindow.Focus(); }
                 Dispatcher.BeginInvoke((Action) FocusAction);
                 return;
             }

--- a/UCR/Views/MainWindow.xaml.cs
+++ b/UCR/Views/MainWindow.xaml.cs
@@ -26,7 +26,7 @@ namespace HidWizards.UCR.Views
         private UCRTrayIcon TrayIcon;
         private readonly DashboardViewModel _dashboardViewModel;
         private CloseState WindowCloseState { get; set; }
-        private Dictionary<Guid, ProfileWindow> ProfileWindows;
+        internal Dictionary<Guid, ProfileWindow> ProfileWindows;
 
         enum CloseState
         {

--- a/UCR/Views/MainWindow.xaml.cs
+++ b/UCR/Views/MainWindow.xaml.cs
@@ -335,13 +335,13 @@ namespace HidWizards.UCR.Views
             StopProfileStrip.Enabled = false;
             TrayIcon.Text = "Universal Control Remapper";
             TrayIcon.Icon = System.Drawing.Icon.ExtractAssociatedIcon(System.Windows.Forms.Application.ExecutablePath);
-            TrayIcon.Click += TrayIcon_OnClick;
+            TrayIcon.DoubleClick += TrayIcon_OnDoubleClick;
             TrayIcon.ContextMenuStrip = new System.Windows.Forms.ContextMenuStrip();
             TrayIcon.ContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { StopProfileStrip });
             TrayIcon.Visible = true;
         }
 
-        private void TrayIcon_OnClick(object sender, EventArgs e)
+        private void TrayIcon_OnDoubleClick(object sender, EventArgs e)
         {
             this.Show();
         }

--- a/UCR/Views/MainWindow.xaml.cs
+++ b/UCR/Views/MainWindow.xaml.cs
@@ -302,10 +302,10 @@ namespace HidWizards.UCR.Views
             var data = (NativeMethods.COPYDATASTRUCT)Marshal.PtrToStructure(lParam, typeof(NativeMethods.COPYDATASTRUCT));
             var argsString = Marshal.PtrToStringAnsi(data.lpData);
             if (!string.IsNullOrEmpty(argsString)) Context.ParseCommandLineArguments(argsString.Split(';'));
-            if (Context.StartHidden)
+            if (Context.Minimized)
             {
                 this.Hide();
-                Context.StartHidden = false;
+                Context.Minimized = false;
             }
             return IntPtr.Zero;
         }

--- a/UCR/Views/MainWindow.xaml.cs
+++ b/UCR/Views/MainWindow.xaml.cs
@@ -27,8 +27,11 @@ namespace HidWizards.UCR.Views
         private CloseState WindowCloseState { get; set; }
         private Dictionary<Guid, ProfileWindow> ProfileWindows;
         private System.Windows.Forms.NotifyIcon TrayIcon = new System.Windows.Forms.NotifyIcon();
-        private System.Windows.Forms.ToolStripItem StopProfileStrip = new System.Windows.Forms.ToolStripButton();
-        
+        private System.Windows.Forms.ToolStripItem ShowStrip = new System.Windows.Forms.ToolStripMenuItem();
+        private System.Windows.Forms.ToolStripItem StartLastProfileStrip = new System.Windows.Forms.ToolStripMenuItem();
+        private System.Windows.Forms.ToolStripItem StopProfileStrip = new System.Windows.Forms.ToolStripMenuItem();
+        private System.Windows.Forms.ToolStripItem ExitStrip = new System.Windows.Forms.ToolStripMenuItem();
+
         enum CloseState
         {
             None,
@@ -91,7 +94,6 @@ namespace HidWizards.UCR.Views
                 // TODO Move to dialog
                 MessageBox.Show("The Profile could not be activated, see the log for more details", "Profile failed to activate!", MessageBoxButton.OK, MessageBoxImage.Exclamation);
             }
-            else StopProfileStrip.Enabled = true;
         }
 
         private void DeactivateProfile(object sender, RoutedEventArgs e)
@@ -103,7 +105,6 @@ namespace HidWizards.UCR.Views
                 // TODO Move to dialog
                 MessageBox.Show("The active Profile could not be deactivated, see the log for more details", "Profile failed to deactivate!", MessageBoxButton.OK, MessageBoxImage.Exclamation);
             }
-            else StopProfileStrip.Enabled = false;
         }
 
         private void DeactivateProfile(object sender, EventArgs e)
@@ -115,7 +116,6 @@ namespace HidWizards.UCR.Views
                 // TODO Move to dialog
                 MessageBox.Show("The active Profile could not be deactivated, see the log for more details", "Profile failed to deactivate!", MessageBoxButton.OK, MessageBoxImage.Exclamation);
             }
-            else StopProfileStrip.Enabled = false;
         }
 
         private async void AddProfile(object sender, RoutedEventArgs e)
@@ -282,6 +282,7 @@ namespace HidWizards.UCR.Views
                         break;
                 }
             }
+            TrayIcon.Visible = false;
         }
         
         private void Save_OnExecuted(object sender, ExecutedRoutedEventArgs e)
@@ -329,21 +330,70 @@ namespace HidWizards.UCR.Views
 
         private void InitTrayIcon()
         {
-            StopProfileStrip.Text = "Stop Current Profile";
+            ShowStrip.Text = "Show";
+            ShowStrip.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            ShowStrip.Click += ShowStrip_Click;
+
+            StartLastProfileStrip.Text = "Activate Last Profile";
+            StartLastProfileStrip.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            StartLastProfileStrip.Click += StartLastProfileStrip_Click;
+            StartLastProfileStrip.Enabled = false;
+
+            StopProfileStrip.Text = "Stop Active Profile";
             StopProfileStrip.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             StopProfileStrip.Click += DeactivateProfile;
             StopProfileStrip.Enabled = false;
+
+            ExitStrip.Text = "Exit";
+            ExitStrip.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            ExitStrip.Click += ExitStrip_Click;
+
+            Context.ActiveProfileChangedEvent += Context_ActiveProfileChangedEvent;
+
             TrayIcon.Text = "Universal Control Remapper";
             TrayIcon.Icon = System.Drawing.Icon.ExtractAssociatedIcon(System.Windows.Forms.Application.ExecutablePath);
             TrayIcon.DoubleClick += TrayIcon_OnDoubleClick;
             TrayIcon.ContextMenuStrip = new System.Windows.Forms.ContextMenuStrip();
-            TrayIcon.ContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { StopProfileStrip });
+            TrayIcon.ContextMenuStrip.ShowCheckMargin = false;
+            TrayIcon.ContextMenuStrip.ShowImageMargin = false;
+            TrayIcon.ContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { ShowStrip, new System.Windows.Forms.ToolStripSeparator(), StartLastProfileStrip, StopProfileStrip, new System.Windows.Forms.ToolStripSeparator(), ExitStrip });
             TrayIcon.Visible = true;
+        }
+
+        private void Context_ActiveProfileChangedEvent(Profile profile)
+        {
+            if(profile == null)
+            {
+                StopProfileStrip.Enabled = false;
+            }
+            else
+            {
+                StopProfileStrip.Enabled = true;
+                StartLastProfileStrip.Text = $"Activate Last Profile: {profile.Title}";
+                StartLastProfileStrip.Enabled = true;
+            }
+        }
+
+        private void ExitStrip_Click(object sender, EventArgs e)
+        {
+            Close();
+        }
+
+        private void StartLastProfileStrip_Click(object sender, EventArgs e)
+        {
+            Context.SubscriptionsManager.ActivateLastProfile();
+            StopProfileStrip.Enabled = true;
+        }
+
+        private void ShowStrip_Click(object sender, EventArgs e)
+        {
+            Show();
+            Activate();
         }
 
         private void TrayIcon_OnDoubleClick(object sender, EventArgs e)
         {
-            this.Show();
+            Show();
         }
         private async void About_OnClick(object sender, RoutedEventArgs e)
         {

--- a/UCR/Views/MainWindow.xaml.cs
+++ b/UCR/Views/MainWindow.xaml.cs
@@ -26,7 +26,7 @@ namespace HidWizards.UCR.Views
         private UCRTrayIcon TrayIcon;
         private readonly DashboardViewModel _dashboardViewModel;
         private CloseState WindowCloseState { get; set; }
-        internal Dictionary<Guid, ProfileWindow> ProfileWindows;
+        private Dictionary<Guid, ProfileWindow> ProfileWindows;
 
         enum CloseState
         {

--- a/UCR/Views/MainWindow.xaml.cs
+++ b/UCR/Views/MainWindow.xaml.cs
@@ -42,6 +42,7 @@ namespace HidWizards.UCR.Views
             Context = context;
             ProfileWindows = new Dictionary<Guid, ProfileWindow>();
             TrayIcon = new UCRTrayIcon(this);
+            Context.MinimizedToTrayEvent += Context_MinimizedToTrayEvent;
             InitializeComponent();
         }
 
@@ -287,11 +288,6 @@ namespace HidWizards.UCR.Views
             var data = (NativeMethods.COPYDATASTRUCT)Marshal.PtrToStructure(lParam, typeof(NativeMethods.COPYDATASTRUCT));
             var argsString = Marshal.PtrToStringAnsi(data.lpData);
             if (!string.IsNullOrEmpty(argsString)) Context.ParseCommandLineArguments(argsString.Split(';'));
-            if (Context.Minimized)
-            {
-                this.Hide();
-                Context.Minimized = false;
-            }
             return IntPtr.Zero;
         }
 
@@ -329,6 +325,11 @@ namespace HidWizards.UCR.Views
         {
             var treeView = sender as TreeView;
             _dashboardViewModel.SelectedProfileItem = treeView?.SelectedItem as ProfileItem;
+        }
+
+        private void Context_MinimizedToTrayEvent()
+        {
+            Hide();
         }
     }
 }

--- a/UCR/Views/MainWindow.xaml.cs
+++ b/UCR/Views/MainWindow.xaml.cs
@@ -22,15 +22,11 @@ namespace HidWizards.UCR.Views
 
     public partial class MainWindow : Window
     {
-        private Context Context { get; set; }
+        internal Context Context { get; set; }
+        private UCRTrayIcon TrayIcon;
         private readonly DashboardViewModel _dashboardViewModel;
         private CloseState WindowCloseState { get; set; }
         private Dictionary<Guid, ProfileWindow> ProfileWindows;
-        private System.Windows.Forms.NotifyIcon TrayIcon = new System.Windows.Forms.NotifyIcon();
-        private System.Windows.Forms.ToolStripItem ShowStrip = new System.Windows.Forms.ToolStripMenuItem();
-        private System.Windows.Forms.ToolStripItem StartLastProfileStrip = new System.Windows.Forms.ToolStripMenuItem();
-        private System.Windows.Forms.ToolStripItem StopProfileStrip = new System.Windows.Forms.ToolStripMenuItem();
-        private System.Windows.Forms.ToolStripItem ExitStrip = new System.Windows.Forms.ToolStripMenuItem();
 
         enum CloseState
         {
@@ -45,7 +41,7 @@ namespace HidWizards.UCR.Views
             DataContext = _dashboardViewModel;
             Context = context;
             ProfileWindows = new Dictionary<Guid, ProfileWindow>();
-            InitTrayIcon();
+            TrayIcon = new UCRTrayIcon(this);
             InitializeComponent();
         }
 
@@ -96,21 +92,10 @@ namespace HidWizards.UCR.Views
             }
         }
 
-        private void DeactivateProfile(object sender, RoutedEventArgs e)
+        internal void DeactivateProfile(object sender, RoutedEventArgs e)
         {
             if (Context.ActiveProfile == null) return;
             
-            if (!Context.SubscriptionsManager.DeactivateCurrentProfile())
-            {
-                // TODO Move to dialog
-                MessageBox.Show("The active Profile could not be deactivated, see the log for more details", "Profile failed to deactivate!", MessageBoxButton.OK, MessageBoxImage.Exclamation);
-            }
-        }
-
-        private void DeactivateProfile(object sender, EventArgs e)
-        {
-            if (Context.ActiveProfile == null) return;
-
             if (!Context.SubscriptionsManager.DeactivateCurrentProfile())
             {
                 // TODO Move to dialog
@@ -327,74 +312,7 @@ namespace HidWizards.UCR.Views
             var error = Marshal.GetLastWin32Error();
             MessageBox.Show($"Enabling message handling failed with the error: {error}");
         }
-
-        private void InitTrayIcon()
-        {
-            ShowStrip.Text = "Show";
-            ShowStrip.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            ShowStrip.Click += ShowStrip_Click;
-
-            StartLastProfileStrip.Text = "Activate Last Profile";
-            StartLastProfileStrip.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            StartLastProfileStrip.Click += StartLastProfileStrip_Click;
-            StartLastProfileStrip.Enabled = false;
-
-            StopProfileStrip.Text = "Stop Active Profile";
-            StopProfileStrip.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            StopProfileStrip.Click += DeactivateProfile;
-            StopProfileStrip.Enabled = false;
-
-            ExitStrip.Text = "Exit";
-            ExitStrip.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            ExitStrip.Click += ExitStrip_Click;
-
-            Context.ActiveProfileChangedEvent += Context_ActiveProfileChangedEvent;
-
-            TrayIcon.Text = "Universal Control Remapper";
-            TrayIcon.Icon = System.Drawing.Icon.ExtractAssociatedIcon(System.Windows.Forms.Application.ExecutablePath);
-            TrayIcon.DoubleClick += TrayIcon_OnDoubleClick;
-            TrayIcon.ContextMenuStrip = new System.Windows.Forms.ContextMenuStrip();
-            TrayIcon.ContextMenuStrip.ShowCheckMargin = false;
-            TrayIcon.ContextMenuStrip.ShowImageMargin = false;
-            TrayIcon.ContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { ShowStrip, new System.Windows.Forms.ToolStripSeparator(), StartLastProfileStrip, StopProfileStrip, new System.Windows.Forms.ToolStripSeparator(), ExitStrip });
-            TrayIcon.Visible = true;
-        }
-
-        private void Context_ActiveProfileChangedEvent(Profile profile)
-        {
-            if(profile == null)
-            {
-                StopProfileStrip.Enabled = false;
-            }
-            else
-            {
-                StopProfileStrip.Enabled = true;
-                StartLastProfileStrip.Text = $"Activate Last Profile: {profile.Title}";
-                StartLastProfileStrip.Enabled = true;
-            }
-        }
-
-        private void ExitStrip_Click(object sender, EventArgs e)
-        {
-            Close();
-        }
-
-        private void StartLastProfileStrip_Click(object sender, EventArgs e)
-        {
-            Context.SubscriptionsManager.ActivateLastProfile();
-            StopProfileStrip.Enabled = true;
-        }
-
-        private void ShowStrip_Click(object sender, EventArgs e)
-        {
-            Show();
-            Activate();
-        }
-
-        private void TrayIcon_OnDoubleClick(object sender, EventArgs e)
-        {
-            Show();
-        }
+        
         private async void About_OnClick(object sender, RoutedEventArgs e)
         {
             var dialog = new AboutDialog();


### PR DESCRIPTION
**Added**
(Requested in #53) Add a tray icon with double click showing the main window to the foreground, as well as four right click options:
- Show: Identical to double click
- Activate Last Profile: {Profile Name}
- Stop Active Profile
- Exit: Calls for the main window to close itself, exiting the program

(Requested in #150) Add a CLI argument, -h|hidden, to start the program without calling Show() on the main window, while still activating any profile specified by -p|profile=. Hides first instance if called with second instance. Will not work if EditProfile window is open.
Icon will also produce a notification about itself when the -h|hidden argument is received.

**Changes**
- Move parsing of CMD arguments to after the initialization of the main window, as otherwise the tray icon would not initialize correctly if a profile was specified via the CLI
- Store last profile in SubscriptionManager, to be used in ActivateLastProfile
- Change some members of MainWindow to Internal from Private, as the TrayIcon needs to access them
- Change behavior of "Edit Profile" button to make it behave better when an existing edit window has been minimized
- Add TrayIcon.visibility=false to MainWindow_OnClosing to properly remove Trayicon, otherwise it lingers until interacted with