### PR TITLE
Fix Dead ViGEm Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ UCR supports input and output devices through plugins using the [IOWrapper](http
 
 ### Supported output ###
 
-- Xbox 360 controller (XInput) (using [ViGEm](https://github.com/nefarius/ViGEm))
-- Dualshock 4 controller (using [ViGEm](https://github.com/nefarius/ViGEm))
+- Xbox 360 controller (XInput) (using [ViGEm](https://github.com/ViGEm/ViGEmBus))
+- Dualshock 4 controller (using [ViGEm](https://github.com/ViGEm/ViGEmBus))
 - DirectInput controller (using [vJoy](https://github.com/shauleiz/vJoy))
 - Keyboard (using [interception](https://github.com/oblitum/Interception))
 - Mouse (using [interception](https://github.com/oblitum/Interception))


### PR DESCRIPTION
This commit fixes two dead links in the README from https://github.com/nefarius/ViGEm to https://github.com/ViGEm/ViGEmBus