### PR TITLE
Add Remappers for Toggle Switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added System Tray Icon
 - Added Hidden mode CLI Argument (-h|hidden)
 - Added JumpList to task bar context menu for faster access to recent profiles 
+- Added Toggle Switch Remappers
 
 ## [0.9.0] - 2020-01-02
 

--- a/UCR.Plugins/Remapper/Switch3WayToButtons.cs
+++ b/UCR.Plugins/Remapper/Switch3WayToButtons.cs
@@ -1,0 +1,78 @@
+﻿using HidWizards.UCR.Core.Attributes;
+using HidWizards.UCR.Core.Models;
+using HidWizards.UCR.Core.Models.Binding;
+using System.Timers;
+
+namespace HidWizards.UCR.Plugins.Remapper
+{
+    [Plugin("Switch 3 Way to Buttons", Group = "Button", Description = "Map from one On-Off-On toggle swicth to three momentary buttons")]
+    [PluginInput(DeviceBindingCategory.Momentary, "Switch Up")]
+    [PluginInput(DeviceBindingCategory.Momentary, "Switch Down")]
+    [PluginOutput(DeviceBindingCategory.Momentary, "Button Up")]
+    [PluginOutput(DeviceBindingCategory.Momentary, "Button Center")]
+    [PluginOutput(DeviceBindingCategory.Momentary, "Button Down")]
+    public class Switch3WayToButtons : Plugin
+    {
+
+        [PluginGui("Button Press Durration (ms)")]
+        public int durration { get; set; }
+
+        private System.Timers.Timer topTimer, centerTimer, bottomTimer;
+
+        public Switch3WayToButtons() {
+            durration = 50;
+            topTimer = new Timer {
+                Interval = durration,
+                AutoReset = false,
+                Enabled = false
+            };
+            centerTimer = new Timer {
+                Interval = durration,
+                AutoReset = false,
+                Enabled = false
+            };
+            bottomTimer = new Timer {
+                Interval = durration,
+                AutoReset = false,
+                Enabled = false
+            };
+            topTimer.Elapsed += this.OnTopTimeElapsed;
+            centerTimer.Elapsed += this.OnCenterTimerElapsed;
+            bottomTimer.Elapsed += this.OnBottomTimerElapsed;
+        }
+
+        private void OnTopTimeElapsed(System.Object source, ElapsedEventArgs e) {
+            WriteOutput(0, 0);
+        }
+
+        private void OnCenterTimerElapsed(System.Object source, ElapsedEventArgs e) {
+            WriteOutput(1, 0);
+        }
+
+        private void OnBottomTimerElapsed(System.Object source, ElapsedEventArgs e) {
+            WriteOutput(2, 0);
+        }
+
+        public override void Update(params short[] values)
+        {
+            if (values[0] == 0 && values[1] == 0) //center
+            {
+                WriteOutput(1, 1);
+                centerTimer.Interval = durration;
+                centerTimer.Start();
+            } 
+            else if (values[0] == 0 && values[1] == 1) //top
+            {
+                WriteOutput(0, 1);
+                topTimer.Interval = durration;
+                topTimer.Start();
+            } 
+            else //bottom
+            {
+                WriteOutput(2, 1);
+                bottomTimer.Interval = durration;
+                bottomTimer.Start();
+            }
+        }
+    }
+}

--- a/UCR.Plugins/Remapper/SwitchToButtons.cs
+++ b/UCR.Plugins/Remapper/SwitchToButtons.cs
@@ -1,0 +1,64 @@
+﻿using HidWizards.UCR.Core.Attributes;
+using HidWizards.UCR.Core.Models;
+using HidWizards.UCR.Core.Models.Binding;
+using System.Timers;
+
+namespace HidWizards.UCR.Plugins.Remapper
+{
+    [Plugin("Switch to Buttons", Group = "Button", Description = "Map from one swicth to two momentary buttons")]
+    [PluginInput(DeviceBindingCategory.Momentary, "Button")]
+    [PluginOutput(DeviceBindingCategory.Momentary, "ButtonOn")]
+    [PluginOutput(DeviceBindingCategory.Momentary, "ButtonOff")]
+    public class SwitchToButtons : Plugin
+    {
+
+        [PluginGui("Button Press Durration (ms)")]
+        public int durration { get; set; }
+
+        private System.Timers.Timer onTimer, offTimer;
+
+        public SwitchToButtons() {
+            durration = 50;
+            onTimer = new Timer {
+                Interval = durration,
+                AutoReset = false,
+                Enabled = false
+            };
+            offTimer = new Timer {
+                Interval = durration,
+                AutoReset = false,
+                Enabled = false
+            };
+            onTimer.Elapsed += this.OnOnTimerElapsed;
+            offTimer.Elapsed += this.OnOffTimerElapsed;
+        }
+
+        private void OnOnTimerElapsed(System.Object source, ElapsedEventArgs e) {
+            WriteOutput(1, 0);
+        }
+
+        private void OnOffTimerElapsed(System.Object source, ElapsedEventArgs e) {
+            WriteOutput(0, 0);
+        }
+
+        public override void Update(params short[] values)
+        {
+            if (values[0] == 0)
+            {
+                WriteOutput(0, 1);
+                //Thread.Sleep(durration);
+                offTimer.Interval = durration;
+                offTimer.Start();
+                //WriteOutput(0, 0);
+            }
+            else
+            {
+                WriteOutput(1, 1);
+                //Thread.Sleep(durration);
+                onTimer.Interval = durration;
+                onTimer.Start();
+                //WriteOutput(1, 0);
+            }
+        }
+    }
+}

--- a/UCR.Plugins/Remapper/SwitchToToggleButton.cs
+++ b/UCR.Plugins/Remapper/SwitchToToggleButton.cs
@@ -1,0 +1,62 @@
+﻿using HidWizards.UCR.Core.Attributes;
+using HidWizards.UCR.Core.Models;
+using HidWizards.UCR.Core.Models.Binding;
+using System.Timers;
+
+namespace HidWizards.UCR.Plugins.Remapper
+{
+    [Plugin("Switch to Toggle Buttons", Group = "Button", Description = "Map from one switch to a single button that is pressed each time the switch moves.")]
+    [PluginInput(DeviceBindingCategory.Momentary, "Button")]
+    [PluginOutput(DeviceBindingCategory.Momentary, "Button")]
+    public class SwitchToToggleButton : Plugin
+    {
+
+        [PluginGui("Button Press Durration (ms)")]
+        public int durration { get; set; }
+
+        //This exists to allow a fast flip back and forth to register as only one button press so that switch state and game state can be put into sync.
+        [PluginGui("Min time between presses (ms)")]
+        public int minFlip { get; set; }
+
+        private System.Timers.Timer flipTimer, offTimer;
+        private bool doPress = true;
+
+        public SwitchToToggleButton() {
+            minFlip = 250;
+            durration = 50;
+            flipTimer = new Timer {
+                Interval = durration,
+                AutoReset = false,
+                Enabled = false
+            };
+            flipTimer.Elapsed += this.OnFlipTimerElapsed;
+            offTimer = new Timer {
+                Interval = minFlip,
+                AutoReset = false,
+                Enabled = false
+            };
+            offTimer.Elapsed += this.OnOffTimerElapsed;
+        }
+
+        private void OnFlipTimerElapsed(System.Object source, ElapsedEventArgs e) {
+            doPress = true;
+        }
+
+        private void OnOffTimerElapsed(System.Object source, ElapsedEventArgs e) {
+            WriteOutput(0, 0);
+        }
+
+        public override void Update(params short[] values)
+        {
+            if(doPress)
+            {
+                WriteOutput(0, 1);
+                offTimer.Interval = durration;
+                offTimer.Start();
+                doPress = false;
+                flipTimer.Interval = minFlip;
+                flipTimer.Start();
+            }
+        }
+    }
+}

--- a/UCR.Plugins/UCR.Plugins.csproj
+++ b/UCR.Plugins/UCR.Plugins.csproj
@@ -59,6 +59,9 @@
     <Compile Include="Remapper\ButtonToAxis.cs" />
     <Compile Include="Remapper\ButtonToButton.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Remapper\Switch3WayToButtons.cs" />
+    <Compile Include="Remapper\SwitchToButtons.cs" />
+    <Compile Include="Remapper\SwitchToToggleButton.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\UCR.Core\UCR.Core.csproj">


### PR DESCRIPTION
Add three new remappers to support toggle switches.

Add a remapper SwitchToButtons that creates a different momentary button press when a toggle switch is moved to a new possiton.  This is used to allow a two possition toggle switch to map to game controls that have a seperate button for each in game switch position.  (i.e. "Landing Gear Up" and "Landing Gear Down")

Add a remapper SwitchToToggle that creates a momentary press of the same button each time a toggle switch is moved to a new possition.  This is to allow a two position toggle switch to map to game controls that only have a single key to toggle a switch. (i.e. "Toggle Landing Lights").  This will also only create one button press if the switch is flipped back and forth quickly so that if game and physical switch are out of sync (one on and other is off) a quick flip back and forth will put them back in sync.

Add a remapper "Switch3WayToButtons" that creates a different momentary button press when an ON-OFF-ON toggle switch is moved to a each possiton.  This is used to allow a three possition ON-OFF-ON toggle switch connected to two buttons to map to game controls that have a seperate button for each of three in game switch position.  (i.e. "Headlights Off" and "Headlights On" and "Headlight High Beam")