### PR TITLE
Add primed merge mode to axis merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Added primed axis merge mode to axis merge
+
 ## [0.9.0] - 2020-01-02
 
 ### Added

--- a/UCR.Plugins/Remapper/AxisMerger.cs
+++ b/UCR.Plugins/Remapper/AxisMerger.cs
@@ -40,7 +40,8 @@ namespace HidWizards.UCR.Plugins.Remapper
         {
             Average,
             Greatest,
-            Sum
+            Sum,
+            Primed
         }
 
         public AxisMerger()
@@ -74,11 +75,15 @@ namespace HidWizards.UCR.Plugins.Remapper
                 case AxisMergerMode.Sum:
                     valueOutput = Functions.ClampAxisRange(valueHigh + valueLow);
                     break;
+                case AxisMergerMode.Primed:
+                    valueOutput = (short) (valueHigh - ((double) valueHigh / (valueLow < 0? Constants.AxisMinValue : Constants.AxisMaxValue ) - 1) * (double) valueLow);
+                    break;
                 default:
                     valueOutput = 0;
                     break;
             }
 
+            //does deadzone and sensitivity make sense for a merge? Kinda weird for abs merge and is more of a pothole and a speedbump for trim mode I just added, unless it were to be applied to inputs instead of outputs
             if (DeadZone != 0)
             {
                 valueOutput = _deadZoneHelper.ApplyRangeDeadZone(valueOutput);


### PR DESCRIPTION
The "primed merge" mode allows for the center of one axis to be set by the other axis, while still being able to utilize the full range of the axis unlike sum mode. I couldn't find the technical name for this kind of linear interpolation.. primed is kind of a guess at the name.