### PR TITLE
Fix GetDeviceBindingMenu() not using DeviceNumber when searching available devices

### DIFF
--- a/UCR.Core/Managers/DevicesManager.cs
+++ b/UCR.Core/Managers/DevicesManager.cs
@@ -75,7 +75,7 @@ namespace HidWizards.UCR.Core.Managers
 
             try
             {
-                return availableDeviceList.Find(d => d.DeviceHandle == device.DeviceHandle).GetDeviceBindingMenu();
+                return availableDeviceList.Find(d => d.DeviceHandle == device.DeviceHandle && d.DeviceNumber == device.DeviceNumber).GetDeviceBindingMenu();
             }
             catch (Exception ex) when (ex is KeyNotFoundException || ex is ArgumentNullException || ex is NullReferenceException)
             {


### PR DESCRIPTION
A one line change which includes DeviceNumber in the availableDeviceList.Find() query in GetDeviceBindingMenu(). This fixes https://github.com/Snoothy/UCR/issues/230.